### PR TITLE
Add havoc to silver

### DIFF
--- a/src/main/scala/viper/silver/ast/Statement.scala
+++ b/src/main/scala/viper/silver/ast/Statement.scala
@@ -197,6 +197,34 @@ case class Goto(target: String)(val pos: Position = NoPosition, val info: Info =
   */
 case class LocalVarDeclStmt(decl: LocalVarDecl)(val pos: Position = NoPosition, val info: Info = NoInfo, val errT: ErrorTrafo = NoTrafos) extends Stmt
 
+/** Havoc statement.
+  * Replaces the havocked resources snapshot with a fresh snapshot.
+  * The optional lhs provides a guard, under which the resource is havocked. For example,
+  *   havoc c ==> Pred(x)
+  * means that we only havoc Pred(x) if the condition `c` is true.
+  * The "havocall" variant of this statement allows one to havoc an unbounded number of resources
+  */
+case class Havoc(lhs: Option[Exp], exp: ResourceAccess)(val pos: Position = NoPosition, val info: Info = NoInfo, val errT: ErrorTrafo = NoTrafos) extends Stmt {
+  override lazy val check : Seq[ConsistencyError] = {
+    // Add some sanity checks, which should be guaranteed by earlier phases of the front end. These checks
+    // are similar to the ones provided by inhale and exhale statements.
+    (if(!Consistency.noResult(this)) Seq(ConsistencyError("Result variables are only allowed in postconditions of functions.", pos)) else Seq()) ++
+    (if (lhs.nonEmpty && !(lhs.get isSubtype Bool)) Seq(ConsistencyError(s"Left side of havoc implication must be of type Bool, but found ${exp.typ}", exp.pos)) else Seq())
+  }
+}
+
+/** Havocall statement (see Havoc statement)
+  * Must extend Scope because it declares quantified variables.
+  */
+case class Havocall(vars: Seq[LocalVarDecl], lhs: Option[Exp], exp: ResourceAccess)(val pos: Position = NoPosition, val info: Info = NoInfo, val errT: ErrorTrafo = NoTrafos) extends Stmt with Scope {
+  val scopedDecls: Seq[Declaration] = vars
+
+  override lazy val check : Seq[ConsistencyError] = {
+    (if(!Consistency.noResult(this)) Seq(ConsistencyError("Result variables are only allowed in postconditions of functions.", pos)) else Seq()) ++
+    (if (lhs.nonEmpty && !(lhs.get isSubtype Bool)) Seq(ConsistencyError(s"Left side of havocall implication must be of type Bool, but found ${exp.typ}", exp.pos)) else Seq())
+  }
+}
+
 
 /** Generic Statement type to use to extend the AST.
   * New statement-typed AST nodes can be defined by creating new case classes extending this trait.

--- a/src/main/scala/viper/silver/ast/Statement.scala
+++ b/src/main/scala/viper/silver/ast/Statement.scala
@@ -198,15 +198,15 @@ case class Goto(target: String)(val pos: Position = NoPosition, val info: Info =
 case class LocalVarDeclStmt(decl: LocalVarDecl)(val pos: Position = NoPosition, val info: Info = NoInfo, val errT: ErrorTrafo = NoTrafos) extends Stmt
 
 /** Havoc statement.
-  * Replaces the havocked resources snapshot with a fresh snapshot.
+  * Replaces the havocked resource's snapshot with a fresh snapshot.
   * The optional lhs provides a guard, under which the resource is havocked. For example,
   *   havoc c ==> Pred(x)
   * means that we only havoc Pred(x) if the condition `c` is true.
-  * The "havocall" variant of this statement allows one to havoc an unbounded number of resources
+  * The havocall variant of this statement allows one to havoc an unbounded number of resources
   */
 case class Havoc(lhs: Option[Exp], exp: ResourceAccess)(val pos: Position = NoPosition, val info: Info = NoInfo, val errT: ErrorTrafo = NoTrafos) extends Stmt {
-  override lazy val check : Seq[ConsistencyError] = {
-    // Add some sanity checks, which should be guaranteed by earlier phases of the front end. These checks
+  override lazy val check: Seq[ConsistencyError] = {
+    // Sanity checks of properties that should be guaranteed by earlier phases of the front end. These checks
     // are similar to the ones provided by inhale and exhale statements.
     (if(!Consistency.noResult(this)) Seq(ConsistencyError("Result variables are only allowed in postconditions of functions.", pos)) else Seq()) ++
     (if (lhs.nonEmpty && !(lhs.get isSubtype Bool)) Seq(ConsistencyError(s"Left side of havoc implication must be of type Bool, but found ${exp.typ}", exp.pos)) else Seq())

--- a/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
+++ b/src/main/scala/viper/silver/ast/pretty/PrettyPrinter.scala
@@ -690,6 +690,15 @@ object FastPrettyPrinter extends FastPrettyPrinterBase with BracketPrettyPrinter
         text("goto") <+> target
       case LocalVarDeclStmt(decl) =>
         text("var") <+> showVar(decl)
+      case Havoc(lhs, exp) =>
+        text("havoc") <+>
+        (if (lhs.nonEmpty) show(lhs.get) <+> "==>" <> space else nil) <>
+        show(exp)
+      case Havocall(vars, lhs, exp) =>
+        text("havocall") <+>
+        ssep(vars map show, char(',') <> space) <+> "::" <+>
+        (if (lhs.nonEmpty) show(lhs.get) <+> "==>" <> space else nil) <>
+        show(exp)
       case e: ExtensionStmt => e.prettyPrint
       case null => uninitialized
     }

--- a/src/main/scala/viper/silver/ast/utility/Nodes.scala
+++ b/src/main/scala/viper/silver/ast/utility/Nodes.scala
@@ -66,6 +66,8 @@ object Nodes {
           case Label(_, invs) => invs
           case Goto(_) => Nil
           case LocalVarDeclStmt(decl) => Seq(decl)
+          case Havoc(lhs, e) => lhs.toSeq :+ e
+          case Havocall(vars, lhs, e) => vars ++ lhs.toSeq :+ e
           case e: ExtensionStmt => e.extensionSubnodes
         }
       case _: LocalVarDecl => Nil

--- a/src/main/scala/viper/silver/cfg/silver/CfgGenerator.scala
+++ b/src/main/scala/viper/silver/cfg/silver/CfgGenerator.scala
@@ -227,7 +227,9 @@ object CfgGenerator {
            _: NewStmt |
            _: Assert |
            _: LocalVarDeclStmt |
-           _: Assume =>
+           _: Assume |
+           _: Havoc |
+           _: Havocall =>
         // handle regular, non-control statements
         addStatement(WrappedStmt(stmt))
       case _: ExtensionStmt =>

--- a/src/main/scala/viper/silver/parser/FastParser.scala
+++ b/src/main/scala/viper/silver/parser/FastParser.scala
@@ -77,7 +77,7 @@ object FastParserCompanion {
     // specifications
     "requires", "ensures", "invariant",
     // statements
-    "fold", "unfold", "inhale", "exhale", "new", "assert", "assume", "package", "apply",
+    "fold", "unfold", "inhale", "exhale", "new", "assert", "assume", "package", "apply", "havoc", "havocall",
     // control flow
     "while", "if", "elseif", "else", "goto", "label",
     // sequences
@@ -786,7 +786,6 @@ class FastParser {
 
   lazy val keywords = FastParserCompanion.basicKeywords | ParserExtension.extendedKeywords
 
-
   // Note that `typedFapp` is before `"(" ~ exp ~ ")"` to ensure that the latter doesn't gobble up the brackets for the former
   // and then look like an `fapp` up untill the `: type` part, after which we need to backtrack all the way back (or error if cut)
   def atom(implicit ctx : P[_]) : P[PExp] = P(ParserExtension.newExpAtStart(ctx) | integer | booltrue | boolfalse | nul | old
@@ -1091,11 +1090,13 @@ class FastParser {
 
   def stmt(implicit ctx : P[_]) : P[PStmt] = P(ParserExtension.newStmtAtStart(ctx) | macroassign | fieldassign | localassign | fold | unfold | exhale | assertP |
     inhale | assume | ifthnels | whle | varDecl | defineDecl | newstmt | 
-    methodCall | goto | lbl | packageWand | applyWand | macroref | block | ParserExtension.newStmtAtEnd(ctx))
+    methodCall | goto | lbl | packageWand | applyWand | macroref | block |
+    havoc | havocall | ParserExtension.newStmtAtEnd(ctx))
 
   def nodefinestmt(implicit ctx : P[_]) : P[PStmt] = P(ParserExtension.newStmtAtStart(ctx) | fieldassign | localassign | fold | unfold | exhale | assertP |
     inhale | assume | ifthnels | whle | varDecl | newstmt |
-    methodCall | goto | lbl | packageWand | applyWand | macroref | block | ParserExtension.newStmtAtEnd(ctx))
+    methodCall | goto | lbl | packageWand | applyWand | macroref | block |
+    havoc | havocall | ParserExtension.newStmtAtEnd(ctx))
 
   def macroref[_: P]: P[PMacroRef] = FP(idnuse).map { case (pos, a) => PMacroRef(a)(pos) }
 
@@ -1116,6 +1117,28 @@ class FastParser {
   def inhale[_: P]: P[PInhale] = FP(keyword("inhale") ~/ exp).map{ case (pos, e) => PInhale(e)(pos) }
 
   def assume[_: P]: P[PAssume] = FP(keyword("assume") ~/ exp).map{ case (pos, e) => PAssume(e)(pos) }
+
+  // Parsing Havoc statements
+  // Havoc statements have two forms:
+  //    1. havoc <resource>
+  //    2. havoc <exp> ==> <resource>
+  // Note that you cannot generalize (2) to something like "<exp1> ==> <exp2> ==> <resource>".
+  // We therefore forbid the lhs of (2) from being an arbitrary expression. Instead,
+  // we enforce that it's a "magicWandExp", which is one level below an implication expression
+  // in the grammar. Note that it is still possible to express "(<exp1> ==> <exp2>) ==> <resource>
+  // using parentheses.
+
+  // Havocall follows a similar pattern to havoc but allows quantifying over variables.
+
+  def havoc[_: P]: P[PHavoc] = FP(keyword("havoc") ~/
+    (magicWandExp ~ "==>").? ~ exp ).map{
+    case (pos, (lhs, rhs)) => PHavoc(lhs, rhs)(pos)
+  }
+
+  def havocall[_: P]: P[PHavocall] = FP(keyword("havocall") ~/
+    nonEmptyFormalArgList ~ "::" ~ (magicWandExp ~ "==>").? ~ exp).map {
+    case (pos, (vars, lhs, rhs)) => PHavocall(vars, lhs, rhs)(pos)
+  }
 
   def ifthnels[_: P]: P[PIf] = FP("if" ~ "(" ~ exp ~ ")" ~ block ~~~ elsifEls).map {
     case (pos, (cond, thn, ele)) => PIf(cond, thn, ele)(pos)

--- a/src/main/scala/viper/silver/parser/FastParser.scala
+++ b/src/main/scala/viper/silver/parser/FastParser.scala
@@ -1131,8 +1131,8 @@ class FastParser {
   // Havocall follows a similar pattern to havoc but allows quantifying over variables.
 
   def havoc[_: P]: P[PHavoc] = FP(keyword("havoc") ~/
-    (magicWandExp ~ "==>").? ~ exp ).map{
-    case (pos, (lhs, rhs)) => PHavoc(lhs, rhs)(pos)
+    (magicWandExp ~ "==>").? ~ exp ).map {
+      case (pos, (lhs, rhs)) => PHavoc(lhs, rhs)(pos)
   }
 
   def havocall[_: P]: P[PHavocall] = FP(keyword("havocall") ~/

--- a/src/main/scala/viper/silver/parser/ParseAst.scala
+++ b/src/main/scala/viper/silver/parser/ParseAst.scala
@@ -1073,6 +1073,8 @@ case class PTypeVarDecl(idndef: PIdnDef)(val pos: (Position, Position)) extends 
 case class PMacroRef(idnuse : PIdnUse)(val pos: (Position, Position)) extends PStmt
 case class PDefine(idndef: PIdnDef, parameters: Option[Seq[PIdnDef]], body: PNode)(val pos: (Position, Position)) extends PStmt with PLocalDeclaration
 case class PSkip()(val pos: (Position, Position)) extends PStmt
+case class PHavoc(lhs: Option[PExp], e: PExp)(val pos: (Position, Position)) extends PStmt
+case class PHavocall(vars: Seq[PFormalArgDecl], lhs: Option[PExp], e: PExp)(val pos: (Position, Position)) extends PStmt with PScope
 
 sealed trait PNewStmt extends PStmt {
   def target: PIdnUse
@@ -1326,6 +1328,8 @@ object Nodes {
       case PAxiom(idndef, exp) => (if (idndef.isDefined) Seq(idndef.get) else Nil) ++ Seq(exp)
       case PTypeVarDecl(name) => Seq(name)
       case PDefine(idndef, optArgs, body) => Seq(idndef) ++ optArgs.getOrElse(Nil) ++ Seq(body)
+      case PHavoc(lhs, e) => lhs.toSeq :+ e
+      case PHavocall(vars, lhs, e) => vars ++ lhs.toSeq :+ e
       case t : PExtender => t.getSubnodes()
       case _: PSkip => Nil
       case _: PUnnamedFormalArgDecl => Nil

--- a/src/main/scala/viper/silver/parser/Resolver.scala
+++ b/src/main/scala/viper/silver/parser/Resolver.scala
@@ -271,9 +271,41 @@ case class TypeChecker(names: NameAnalyser) {
       case _: PDefine =>
         /* Should have been removed right after parsing */
         sys.error(s"Unexpected node $stmt found")
+      case PHavoc(lhs, e) =>
+        checkHavoc(stmt, lhs, e)
+      case havoc@PHavocall(vars, lhs, e) =>
+        vars foreach (v => check(v.typ))
+        // update the curMember, which contains quantified variable information
+        val oldCurMember = curMember
+        curMember = havoc
+        // Actually type check the havoc
+        checkHavoc(stmt, lhs, e)
+        // restore the previous curMember
+        curMember = oldCurMember
+
       case t:PExtender => t.typecheck(this, names).getOrElse(Nil) foreach(message =>
                               messages ++= FastMessaging.message(t, message))
       case _: PSkip =>
+    }
+  }
+
+  def checkHavoc(stmt: PStmt, lhs: Option[PExp], e: PExp): Unit = {
+    // If there is a condition, make sure that it is a Bool
+    if (lhs.nonEmpty) {
+      check(lhs.get, Bool)
+    }
+    // Make sure that the rhs is a resource
+    val havocError = "Havoc statement must take a field access, predicate, or wand"
+    e match {
+      case _: PFieldAccess => checkTopTyped(e, None)
+      case pc: PCall =>
+        check(e, Bool)
+        // make sure that this is in fact a predicate
+        if (pc.extfunction == null) {
+          messages ++= FastMessaging.message(stmt, havocError)
+        }
+      case _: PMagicWandExp => check(e, Bool)
+      case _ => messages ++= FastMessaging.message(stmt, havocError)
     }
   }
 

--- a/src/main/scala/viper/silver/parser/Transformer.scala
+++ b/src/main/scala/viper/silver/parser/Transformer.scala
@@ -113,6 +113,8 @@ object Transformer {
         case p@PAssert(e) => PAssert(go(e))(p.pos)
         case p@PAssume(e) => PAssume(go(e))(p.pos)
         case p@PInhale(e) => PInhale(go(e))(p.pos)
+        case p@PHavoc(lhs, e) => PHavoc(lhs.map(go), go(e))(p.pos)
+        case p@PHavocall(vars, lhs, e) => PHavocall(vars map go, lhs.map(go), go(e))(p.pos)
           // MAPS:
         //case PExplicitMultiset(elems) => PExplicitMultiset(elems map go)
         case p@PEmptyMap(keyType, valueType) => PEmptyMap(go(keyType), go(valueType))(p.pos)

--- a/src/main/scala/viper/silver/parser/Transformer.scala
+++ b/src/main/scala/viper/silver/parser/Transformer.scala
@@ -113,8 +113,8 @@ object Transformer {
         case p@PAssert(e) => PAssert(go(e))(p.pos)
         case p@PAssume(e) => PAssume(go(e))(p.pos)
         case p@PInhale(e) => PInhale(go(e))(p.pos)
-        case p@PHavoc(lhs, e) => PHavoc(lhs.map(go), go(e))(p.pos)
-        case p@PHavocall(vars, lhs, e) => PHavocall(vars map go, lhs.map(go), go(e))(p.pos)
+        case p@PHavoc(lhs, e) => PHavoc(lhs map go, go(e))(p.pos)
+        case p@PHavocall(vars, lhs, e) => PHavocall(vars map go, lhs map go, go(e))(p.pos)
           // MAPS:
         //case PExplicitMultiset(elems) => PExplicitMultiset(elems map go)
         case p@PEmptyMap(keyType, valueType) => PEmptyMap(go(keyType), go(valueType))(p.pos)

--- a/src/main/scala/viper/silver/parser/Translator.scala
+++ b/src/main/scala/viper/silver/parser/Translator.scala
@@ -239,11 +239,11 @@ case class Translator(program: PProgram) {
       case PWhile(cond, invs, body) =>
         While(exp(cond), invs map exp, stmt(body).asInstanceOf[Seqn])(pos)
       case PHavoc(lhs, e) =>
-        val (newLhs, newE) = havocStmt(lhs, e)
+        val (newLhs, newE) = havocStmtHelper(lhs, e)
         Havoc(newLhs, newE)(pos)
       case PHavocall(vars, lhs, e) =>
         val newVars = vars map liftVarDecl
-        val (newLhs, newE) = havocStmt(lhs, e)
+        val (newLhs, newE) = havocStmtHelper(lhs, e)
         Havocall(newVars, newLhs, newE)(pos)
       case t: PExtender =>   t.translateStmt(this)
       case _: PDefine | _: PSkip =>
@@ -251,7 +251,8 @@ case class Translator(program: PProgram) {
     }
   }
 
-  def havocStmt(lhs: Option[PExp], e: PExp): (Option[Exp], ResourceAccess) = {
+  /** Helper function that translates subexpressions common to a Havoc or Havocall statement */
+  def havocStmtHelper(lhs: Option[PExp], e: PExp): (Option[Exp], ResourceAccess) = {
     val newLhs = lhs.map(exp)
     exp(e) match {
       case exp: FieldAccess => (newLhs, exp)

--- a/src/main/scala/viper/silver/verifier/VerificationError.scala
+++ b/src/main/scala/viper/silver/verifier/VerificationError.scala
@@ -534,7 +534,7 @@ object errors {
     val id = "havoc.failed"
     val text = "Havoc might fail."
 
-    override def pos = offendingNode.exp.pos
+    override val pos = offendingNode.exp.pos
     def withNode(offendingNode: errors.ErrorNode = this.offendingNode) = HavocFailed(offendingNode.asInstanceOf[Havoc], this.reason, this.cached)
     def withReason(r: ErrorReason) = HavocFailed(offendingNode, r, cached)
   }
@@ -546,7 +546,7 @@ object errors {
     val id = "havocall.failed"
     val text = "Havocall might fail."
 
-    override def pos = offendingNode.exp.pos
+    override val pos = offendingNode.exp.pos
     def withNode(offendingNode: errors.ErrorNode = this.offendingNode) = HavocallFailed(offendingNode.asInstanceOf[Havocall], this.reason, this.cached)
     def withReason(r: ErrorReason) = HavocallFailed(offendingNode, r, cached)
   }
@@ -675,7 +675,7 @@ object reasons {
 
   case class HavocallNotInjective(offendingNode: Havocall) extends AbstractErrorReason {
     val id = "havocall.not.injective"
-    def readableMessage = s"Havocall statement $offendingNode might not be injective."
+    val readableMessage = s"Havocall statement $offendingNode might not be injective."
 
     def withNode(offendingNode: errors.ErrorNode = this.offendingNode) = HavocallNotInjective(offendingNode.asInstanceOf[Havocall])
   }

--- a/src/main/scala/viper/silver/verifier/VerificationError.scala
+++ b/src/main/scala/viper/silver/verifier/VerificationError.scala
@@ -530,6 +530,31 @@ object errors {
   def LetWandFailed(offendingNode: LocalVarAssign): PartialVerificationError =
     PartialVerificationError((reason: ErrorReason) => LetWandFailed(offendingNode, reason))
 
+  case class HavocFailed(offendingNode: Havoc, reason: ErrorReason, override val cached: Boolean = false) extends AbstractVerificationError {
+    val id = "havoc.failed"
+    val text = "Havoc might fail."
+
+    override def pos = offendingNode.exp.pos
+    def withNode(offendingNode: errors.ErrorNode = this.offendingNode) = HavocFailed(offendingNode.asInstanceOf[Havoc], this.reason, this.cached)
+    def withReason(r: ErrorReason) = HavocFailed(offendingNode, r, cached)
+  }
+
+  def HavocFailed(offendingNode: Havoc): PartialVerificationError =
+    PartialVerificationError((reason: ErrorReason) => HavocFailed(offendingNode, reason))
+
+  case class HavocallFailed(offendingNode: Havocall, reason: ErrorReason, override val cached: Boolean = false) extends AbstractVerificationError {
+    val id = "havocall.failed"
+    val text = "Havocall might fail."
+
+    override def pos = offendingNode.exp.pos
+    def withNode(offendingNode: errors.ErrorNode = this.offendingNode) = HavocallFailed(offendingNode.asInstanceOf[Havocall], this.reason, this.cached)
+    def withReason(r: ErrorReason) = HavocallFailed(offendingNode, r, cached)
+  }
+
+  def HavocallFailed(offendingNode: Havocall): PartialVerificationError =
+    PartialVerificationError((reason: ErrorReason) => HavocallFailed(offendingNode, reason))
+
+
   case class HeuristicsFailed(offendingNode: ErrorNode, reason: ErrorReason, override val cached: Boolean = false) extends AbstractVerificationError {
     val id = "heuristics.failed"
     val text = "Applying heuristics failed."
@@ -646,6 +671,13 @@ object reasons {
     def readableMessage = s"Quantified resource $offendingNode might not be injective."
 
     def withNode(offendingNode: errors.ErrorNode = this.offendingNode) = QPAssertionNotInjective(offendingNode.asInstanceOf[ResourceAccess])
+  }
+
+  case class HavocallNotInjective(offendingNode: Havocall) extends AbstractErrorReason {
+    val id = "havocall.not.injective"
+    def readableMessage = s"Havocall statement $offendingNode might not be injective."
+
+    def withNode(offendingNode: errors.ErrorNode = this.offendingNode) = HavocallNotInjective(offendingNode.asInstanceOf[Havocall])
   }
 
   case class LabelledStateNotReached(offendingNode: LabelledOld) extends AbstractErrorReason {


### PR DESCRIPTION
This commit contains the changes to Silver to include `havoc` and `havocall` in Viper. These changes are accompanied with many more changes to Silicon.